### PR TITLE
adapt activeml to new amt api

### DIFF
--- a/src/main/scala/sampleclean/activeml/CrowdDemo.scala
+++ b/src/main/scala/sampleclean/activeml/CrowdDemo.scala
@@ -41,7 +41,7 @@ object CrowdDemo {
     val contextMap = crowdData toMap
 
     // set up the crowd parameters
-    val labelGetterParameters = CrowdLabelGetterParameters(maxPointsPerHIT = 20) // So we can do it in one HIT.
+    val labelGetterParameters = CrowdLabelGetterParameters(crowdName = "amt", maxPointsPerHIT = 20, crowdConfig = Map("sandbox" -> true)) // So we can do it in one HIT.
 
     // Group Context for a deduplication task with the restaurant schema.
     val groupContext : GroupLabelingContext = DeduplicationGroupLabelingContext(

--- a/src/main/scala/sampleclean/activeml/CrowdHTTPServer.scala
+++ b/src/main/scala/sampleclean/activeml/CrowdHTTPServer.scala
@@ -101,11 +101,13 @@ object CrowdHTTPServer {
     implicit val formats = Serialization.formats(NoTypeHints)
     val pointsJSON = (points map {point => point._1 -> parse(swrite(point._2.content))}).toMap
     val groupContextJSON = parse(swrite(groupContext.data))
+    val crowdConfigJSON = parse(swrite(parameters.crowdConfig))
     val requestData = compact(render(
       ("configuration" ->
         ("task_type" -> groupContext.taskType) ~
           ("task_batch_size" -> parameters.maxPointsPerHIT) ~
           ("num_assignments" -> parameters.maxVotesPerPoint) ~
+          (parameters.crowdName -> crowdConfigJSON) ~
           ("callback_url" -> ("http://" + parameters.responseServerHost + ":" + parameters.responseServerPort))) ~
         ("group_id" -> groupId) ~
         ("group_context" -> groupContextJSON) ~

--- a/src/main/scala/sampleclean/activeml/CrowdLabelGetter.scala
+++ b/src/main/scala/sampleclean/activeml/CrowdLabelGetter.scala
@@ -66,7 +66,8 @@ case class CrowdLabelGetterParameters
   crowdServerPort: Int=8000,
   crowdServerHost: String="127.0.0.1",
   maxPointsPerHIT: Int=5,
-  maxVotesPerPoint: Int=1
+  maxVotesPerPoint: Int=1,
+  crowdConfig: Object=Map()
   )
 
 


### PR DESCRIPTION
This PR suggests one possible way to deal with different crowds without different subclasses extended from CrowdLabelGetterParameters. 

I'm also wondering if we can deal with different crowd task types in a way similar to this, i.e., not using subclasses. Currently, if a user wants to add a new type of task, they not only need to modify the python code, but also need to add subclasses in the scala code, which is not very convenient I think. 
